### PR TITLE
Downgrade Flask to version 2.0.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # We need to keep older versions as search_that_hash is no longer maintained and both require Click which is not compatible with newer version of Flask.
-Flask==2.1.1
+Flask==2.0.3
 search_that_hash==0.2.8


### PR DESCRIPTION
Downgrade Flask version for compatibility with search_that_hash.